### PR TITLE
Add Flutter web skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Dashboard Web con Flutter
+
+Este repositorio contiene un ejemplo básico de cómo iniciar un proyecto
+web con Flutter. El objetivo es disponer de una interfaz en la cual
+posteriormente se integrarán indicadores provenientes de Power BI Service.
+
+## Estructura
+
+- `flutter_webapp/` Carpeta con el código de la aplicación.
+  - `lib/main.dart` Código principal de la app.
+  - `web/index.html` Entrada para la versión web.
+  - `pubspec.yaml` Configuración del proyecto.
+
+## Puesta en marcha
+
+1. Instalar [Flutter](https://docs.flutter.dev/get-started/install) y
+   asegurarse de tener habilitado el entorno para desarrollo web.
+2. Ejecutar `flutter pub get` dentro de la carpeta `flutter_webapp`.
+3. Correr la aplicación con `flutter run -d chrome` para verla en el
+   navegador. También es posible compilar los archivos estáticos con
+   `flutter build web`.
+4. Una vez desplegada la aplicación, se podrán incorporar en la interfaz
+   las visualizaciones provenientes de Power BI Service.

--- a/flutter_webapp/README.md
+++ b/flutter_webapp/README.md
@@ -1,0 +1,19 @@
+# Flutter Web Dashboard
+
+Este proyecto contiene una estructura básica de aplicación en Flutter para
+publicar un dashboard en la web. Los indicadores de Power BI pueden
+integrarse posteriormente dentro de la aplicación.
+
+## Pasos para correr la aplicación
+
+1. Instala Flutter en tu máquina siguiendo la [documentación oficial](https://docs.flutter.dev/get-started/install).
+2. En la terminal, navega hasta este directorio y ejecuta `flutter pub get` para
+   descargar las dependencias.
+3. Lanza la aplicación web con `flutter run -d chrome` o genera los archivos
+   estáticos con `flutter build web`.
+4. Dentro de `lib/main.dart` se encuentra la lógica principal de la interfaz.
+   Modifica este archivo para integrar las visualizaciones de Power BI
+   utilizando `Power BI Embedded` o cualquier otro mecanismo de integración.
+
+Este directorio solo incluye los archivos esenciales para iniciar un proyecto.
+El usuario puede ampliar la estructura según sus necesidades.

--- a/flutter_webapp/lib/main.dart
+++ b/flutter_webapp/lib/main.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Dashboard Demo',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: const DashboardPage(),
+    );
+  }
+}
+
+class DashboardPage extends StatelessWidget {
+  const DashboardPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Dashboard Demo'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: const [
+            Text(
+              'Indicadores Power BI',
+              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+            ),
+            SizedBox(height: 16),
+            Text('Aqui se integrarán los indicadores de Power BI Service.'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_webapp/pubspec.yaml
+++ b/flutter_webapp/pubspec.yaml
@@ -1,0 +1,17 @@
+name: dashboard_web
+version: 1.0.0
+publish_to: 'none'
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/flutter_webapp/web/index.html
+++ b/flutter_webapp/web/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dashboard Demo</title>
+</head>
+<body>
+  <script src="main.dart.js" type="application/javascript"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple Flutter web project scaffold
- include instructions for running the app in README

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849415b55bc8327ad7ef0779c6287cb