### PR TITLE
Add web iframe example and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,33 @@
-# Dashboard Web con Flutter
+# Dashboard Web y APK con Power BI
 
-Este repositorio contiene un ejemplo básico de cómo iniciar un proyecto
-web con Flutter. El objetivo es disponer de una interfaz en la cual
-posteriormente se integrarán indicadores provenientes de Power BI Service.
+Este repositorio muestra dos maneras sencillas de publicar un dashboard de Power BI:
+
+1. **Aplicación Flutter** ubicada en `flutter_webapp/` que puede compilarse
+   tanto para web como para Android.
+2. **Página HTML simple** en `simple_web/` que incrusta el dashboard mediante un
+   `<iframe>`.
 
 ## Estructura
 
-- `flutter_webapp/` Carpeta con el código de la aplicación.
-  - `lib/main.dart` Código principal de la app.
+- `flutter_webapp/` Código de la app Flutter.
+  - `lib/main.dart` Widget principal que carga el iframe de Power BI.
   - `web/index.html` Entrada para la versión web.
   - `pubspec.yaml` Configuración del proyecto.
+- `simple_web/index.html` Página estática con el iframe.
 
 ## Puesta en marcha
 
-1. Instalar [Flutter](https://docs.flutter.dev/get-started/install) y
-   asegurarse de tener habilitado el entorno para desarrollo web.
-2. Ejecutar `flutter pub get` dentro de la carpeta `flutter_webapp`.
-3. Correr la aplicación con `flutter run -d chrome` para verla en el
-   navegador. También es posible compilar los archivos estáticos con
-   `flutter build web`.
-4. Una vez desplegada la aplicación, se podrán incorporar en la interfaz
-   las visualizaciones provenientes de Power BI Service.
+### Flutter
+
+1. Instala [Flutter](https://docs.flutter.dev/get-started/install) y
+   habilita el entorno para desarrollo web y Android.
+2. Ejecuta `flutter pub get` dentro de `flutter_webapp`.
+3. Para ver la versión web, usa `flutter run -d chrome` o compila los
+   archivos estáticos con `flutter build web`.
+4. Para generar un APK usa `flutter build apk` y encontrarás el archivo
+   en `flutter_webapp/build/app/outputs/flutter-apk/`.
+
+### Página HTML simple
+
+Abre `simple_web/index.html` en cualquier navegador para visualizar el
+iframe con el dashboard.

--- a/flutter_webapp/README.md
+++ b/flutter_webapp/README.md
@@ -1,19 +1,15 @@
 # Flutter Web Dashboard
 
 Este proyecto contiene una estructura básica de aplicación en Flutter para
-publicar un dashboard en la web. Los indicadores de Power BI pueden
-integrarse posteriormente dentro de la aplicación.
+publicar un dashboard en la web o en Android.
 
 ## Pasos para correr la aplicación
 
-1. Instala Flutter en tu máquina siguiendo la [documentación oficial](https://docs.flutter.dev/get-started/install).
-2. En la terminal, navega hasta este directorio y ejecuta `flutter pub get` para
-   descargar las dependencias.
-3. Lanza la aplicación web con `flutter run -d chrome` o genera los archivos
-   estáticos con `flutter build web`.
-4. Dentro de `lib/main.dart` se encuentra la lógica principal de la interfaz.
-   Modifica este archivo para integrar las visualizaciones de Power BI
-   utilizando `Power BI Embedded` o cualquier otro mecanismo de integración.
+1. Instala Flutter siguiendo la [documentación oficial](https://docs.flutter.dev/get-started/install).
+2. Desde este directorio ejecuta `flutter pub get` para descargar las dependencias.
+3. Para la versión web usa `flutter run -d chrome` o genera los archivos estáticos con `flutter build web`.
+4. Para crear un APK ejecuta `flutter build apk`.
+5. Dentro de `lib/main.dart` está la lógica principal que incrusta el iframe de Power BI.
 
 Este directorio solo incluye los archivos esenciales para iniciar un proyecto.
-El usuario puede ampliar la estructura según sus necesidades.
+El usuario puede ampliarlo según sus necesidades.

--- a/simple_web/index.html
+++ b/simple_web/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dashboard Power BI</title>
+  <style>
+    html, body {
+      margin: 0;
+      height: 100%;
+    }
+    iframe {
+      border: 0;
+      width: 100%;
+      height: 100%;
+    }
+  </style>
+</head>
+<body>
+  <iframe title="Dashboard" width="600" height="373.5" src="https://app.powerbi.com/view?r=eyJrIjoiODNmMTc3ZjEtY2EwMC00ZmU3LWIxMDUtNmRkZTIwNmMyMzVlIiwidCI6ImU5NDgwZWI4LTdjZWUtNDJjMi04YzM1LTVkMTIyZWNjNWZkOSIsImMiOjR9" allowfullscreen="true"></iframe>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `simple_web` folder with static HTML embedding the Power BI dashboard
- document how to build the Flutter project for web and Android
- mention the simple HTML page in the main README and flutter README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bd73259e0832781ad5e057ae1b0db